### PR TITLE
Retain logs for 14 days

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -20,8 +20,8 @@ resource_types:
     repository: cfcommunity/slack-notification-resource
 jobs:
 - name: logsearch-s3archiving-check-b.cld.gov.au
-  build_logs_to_retain: 20160 # 14 days
   serial: true
+  build_logs_to_retain: 20160
   plan:
   - do:
     - get: 5m
@@ -41,8 +41,8 @@ jobs:
           :x: $BUILD_JOB_NAME FAILED
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 - name: logsearch-s3archiving-check-d.cld.gov.au
-  build_logs_to_retain: 20160 # 14 days
   serial: true
+  build_logs_to_retain: 20160
   plan:
   - do:
     - get: 5m
@@ -62,8 +62,8 @@ jobs:
           :x: $BUILD_JOB_NAME FAILED
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 - name: logsearch-s3archiving-check-y.cld.gov.au
-  build_logs_to_retain: 20160 # 14 days
   serial: true
+  build_logs_to_retain: 20160
   plan:
   - do:
     - get: 5m

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -20,6 +20,7 @@ resource_types:
     repository: cfcommunity/slack-notification-resource
 jobs:
 - name: logsearch-s3archiving-check-b.cld.gov.au
+  build_logs_to_retain: 20160 # 14 days
   serial: true
   plan:
   - do:
@@ -40,6 +41,7 @@ jobs:
           :x: $BUILD_JOB_NAME FAILED
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 - name: logsearch-s3archiving-check-d.cld.gov.au
+  build_logs_to_retain: 20160 # 14 days
   serial: true
   plan:
   - do:
@@ -60,6 +62,7 @@ jobs:
           :x: $BUILD_JOB_NAME FAILED
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 - name: logsearch-s3archiving-check-y.cld.gov.au
+  build_logs_to_retain: 20160 # 14 days
   serial: true
   plan:
   - do:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -21,7 +21,7 @@ resource_types:
 jobs:
 - name: logsearch-s3archiving-check-b.cld.gov.au
   serial: true
-  build_logs_to_retain: 20160
+  build_logs_to_retain: 4032
   plan:
   - do:
     - get: 5m
@@ -42,7 +42,7 @@ jobs:
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 - name: logsearch-s3archiving-check-d.cld.gov.au
   serial: true
-  build_logs_to_retain: 20160
+  build_logs_to_retain: 4032
   plan:
   - do:
     - get: 5m
@@ -63,7 +63,7 @@ jobs:
           <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 - name: logsearch-s3archiving-check-y.cld.gov.au
   serial: true
-  build_logs_to_retain: 20160
+  build_logs_to_retain: 4032
   plan:
   - do:
     - get: 5m


### PR DESCRIPTION
Given these jobs run every 5 minutes, limiting the number of retained build logs seems safe. I've gone with 14 days worth (12 per hour * 24 * 14)